### PR TITLE
[Arch] Phase 2 types — #12, #14, #15

### DIFF
--- a/_system/HANDOFF.md
+++ b/_system/HANDOFF.md
@@ -2,43 +2,38 @@ Last updated: 2026-06-08
 
 ## Current phase
 
-Phase 1 — COMPLETE. All 9 Phase 1 issues shipped.
+Phase 2 — IN PROGRESS. Arch PR open; all agents blocked until merge.
 
 ## Active agent for next session
 
-**Next: Coda — Phase 2 kickoff**
-Check Arch issues (#12, #14, #15) — Phase 2 requires type changes before agents can build.
-Arch must go first (single-PR rule).
+**After Arch PR merges:** Atlas and Aria unblock in parallel (see priority order below).
 
-## Last issues closed
+## Last issue closed
 
-- #7 [Atlas] Parallel broadcast — Promise.allSettled + runProviderIsolated, one failure never kills others
-- #4 [Aria] Model selector panel — ModelSelectorPanel above InputBar, shake UX on last-active guard, prefers-reduced-motion
+Arch #12 / #14 / #15 — Phase 2 type additions PR opened (branch: 12-14-15-arch-phase2-types).
 
-## Phase 1 complete — all shipped
+## Decisions made this session
 
-#3 Aria chat layout · #4 Aria model selector · #5 Atlas Claude · #6 Atlas GPT-5.5
-#7 Atlas parallel broadcast · #8 Vault LocalStorage · #9 Vault ghost mode
-#10 Gate API keys · #30 Gate theme storage
+- `InteractionModeConfig` added — display metadata for mode-switcher UI (Aria #12 / #7).
+- `ChainStep` + `AutoChainConfig` added — cross-agent contract for auto-chain sequencing (Atlas #14).
+- `SessionTokenUsage` added — per-model running totals shape (Atlas #15 / Aria #16).
+- `ConversationStore.getSessionTokenUsage()` method signature added — Vault implements, Aria reads.
+- `ChainStep.appendToContext` boolean controls whether a model's response feeds the next step.
+- `AutoChainConfig.maxPasses` caps runaway chains at the type level.
+- Atlas standalone `getSessionTokenUsage()` from @/models remains a documented exception.
 
-## Phase 2 issues (priority order)
+## Phase 2 priority order (after Arch PR merges)
 
-Arch first (type changes required before any agent builds):
-1. [Arch] #12 — Interaction mode switcher types
-2. [Arch] #14 — Directed reply routing types
-3. [Arch] #15 — Token usage tracking types
-
-After Arch PRs merge, agents unblock in parallel:
-4. [Atlas] Directed reply routing (#14 dependency)
-5. [Atlas] Token usage tracking (#15 dependency)
-6. [Aria] Directed reply UI (#11, needs Atlas #14)
-7. [Aria] Interaction mode switcher (#12 dependency)
-8. [Aria] Per-model system prompt UI (#13)
-9. [Aria] Token usage display (#16, needs Atlas #15)
+1. [Atlas] Directed reply routing (#14) — SendMessageOptions.targetModelId + auto-chain sequencing
+2. [Atlas] Token usage tracking (#15) — parse + aggregate SessionTokenUsage, expose getSessionTokenUsage()
+3. [Aria] Interaction mode switcher (#12) — InteractionModeConfig registry + switcher UI
+4. [Aria] Per-model system prompt UI (#13)
+5. [Aria] Directed reply UI (#11) — depends Atlas #14
+6. [Aria] Token usage display (#16) — depends Atlas #15
 
 ## Gotchas
 
-- Single-PR rule on types/index.ts — Arch issues must not overlap
+- Single-PR rule on types/index.ts — Arch PR must merge before any agent starts implementation
 - Outrun shadow values use rgba neon glow — do not flatten in Tailwind config
 - Gate's ApiKeyPanel requiredKeys prop wired — Aria passes active model keys
 - getSessionTokenUsage() exported from @/models — Aria may import (documented exception)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -170,6 +170,8 @@ export interface SendMessageOptions {
   content: string;
   /** Phase 2 — omit to broadcast to all active models. */
   targetModelId?: ModelId;
+  /** Phase 2 — omit for parallel/manual modes. Atlas uses this to sequence auto-chain calls. */
+  chainConfig?: AutoChainConfig;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,47 @@ export type InteractionMode = 'parallel' | 'manual' | 'auto-chain';
 
 export type MessageRole = 'user' | 'assistant';
 
+/**
+ * Display metadata for a single interaction mode. Aria uses a typed registry
+ * of these to render the mode-switcher control and tooltips (issue #12).
+ */
+export interface InteractionModeConfig {
+  mode: InteractionMode;
+  /** Short label shown in the switcher button. */
+  label: string;
+  /** One-sentence description shown in the tooltip. */
+  description: string;
+}
+
+/**
+ * A single step in an auto-chain sequence.
+ * Defines which model speaks at this position and what role it plays.
+ */
+export interface ChainStep {
+  /** Index of this step in the chain (0-based). */
+  stepIndex: number;
+  modelId: ModelId;
+  /**
+   * When true, this model's response is appended to the shared context before
+   * the next step runs. When false the step runs in isolation.
+   */
+  appendToContext: boolean;
+}
+
+/**
+ * Configuration for an auto-chain run. Atlas uses this to sequence
+ * model calls; Aria may read it to render chain progress (issue #14).
+ */
+export interface AutoChainConfig {
+  /** Ordered steps to execute. */
+  steps: ChainStep[];
+  /**
+   * Maximum number of times the full step sequence may repeat before
+   * the chain terminates automatically. 1 = single pass.
+   */
+  maxPasses: number;
+}
+
 export type CredentialKey = 'anthropic' | 'openai';
 
 export type ExportFormat = 'markdown' | 'html';
@@ -23,6 +64,17 @@ export type ExportFormat = 'markdown' | 'html';
 // ─── Token usage ──────────────────────────────────────────────────────────────
 
 export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * Running session totals for a single model. Aria reads this to display
+ * per-model usage in the UI (issue #15 / #16).
+ */
+export interface SessionTokenUsage {
+  modelId: ModelId;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -88,6 +140,13 @@ export interface ConversationStore {
   activeConversationId: string | null;
   getConversation(id: string): Conversation | undefined;
   getActiveConversation(): Conversation | undefined;
+  /**
+   * Returns running session token totals for every active model in the given
+   * conversation. Aria uses this for the per-model usage display (issue #15 / #16).
+   * Atlas also exports a standalone getSessionTokenUsage() utility from
+   * @/models for convenience (documented exception to the boundary rule).
+   */
+  getSessionTokenUsage(conversationId: string): SessionTokenUsage[];
 }
 
 // ─── Streaming — sendMessage plumbing ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Strictly-additive Phase 2 type additions to `/src/types/index.ts`. No existing types modified or removed. All three Arch issues batched per the single-PR rule.

### Additions

**Issue #12 — Interaction mode switcher**
- `InteractionModeConfig` — display metadata (`mode`, `label`, `description`) for Aria's switcher control and tooltips. Aria builds a typed registry of these; no runtime code in this file.

**Issue #14 — Directed reply routing**
- `ChainStep` — one step in an auto-chain sequence: `stepIndex`, `modelId`, `appendToContext` (controls whether the model's response feeds into the next step's context).
- `AutoChainConfig` — ordered `steps: ChainStep[]` + `maxPasses` cap. Atlas uses this to sequence calls; Aria may read it to render chain progress.

**Issue #15 — Token usage tracking**
- `SessionTokenUsage` — per-model running totals (`modelId`, `inputTokens`, `outputTokens`, `totalTokens`).
- `ConversationStore.getSessionTokenUsage(conversationId)` — method signature added to the store interface. Vault implements; Aria reads for the per-model usage display.

### What was already present (no changes needed)

- `InteractionMode` union type ✓
- `Message.targetModelId` ✓
- `SendMessageOptions.targetModelId` ✓
- `TokenUsage` per-message interface ✓
- `ModelConfig.systemPrompt` ✓

## Agent review checklist

All active agents must approve before any implementation work begins (single-PR rule).

- [ ] **Atlas** — `AutoChainConfig` / `ChainStep` shape is sufficient for directed reply routing implementation
- [ ] **Aria** — `InteractionModeConfig` is sufficient to build the mode-switcher registry; `SessionTokenUsage` + `getSessionTokenUsage()` is sufficient for the token usage display
- [ ] **Vault** — `getSessionTokenUsage()` signature on `ConversationStore` is implementable

## Test plan

- [x] `npm run lint` — passes (zero warnings)
- [x] `npm run build` — passes (tsc + vite, 39 modules)
- [ ] All active agents approve before merge

Closes #12, #14, #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)