### PR TITLE
[Atlas] Directed reply routing — #14

### DIFF
--- a/_system/HANDOFF.md
+++ b/_system/HANDOFF.md
@@ -6,31 +6,26 @@ Phase 2 — IN PROGRESS
 
 ## Active agents for next session
 
-All agents unblocked after Arch PR #31 merged.
-
-Parallel track A (no dependencies):
-- Atlas — issue #14 (directed reply routing)
-- Atlas — issue #15 (token usage tracking)
+Parallel track A (in flight / unblocked):
+- Atlas — issue #15 (token usage tracking) — next up for Atlas
 - Aria  — issue #12 (interaction mode switcher)
 - Aria  — issue #13 (per-model system prompt UI)
 
-Parallel track B (depends on Atlas shipping first):
-- Aria  — issue #11 (directed reply UI) → needs Atlas #14
+Parallel track B (unblocked — Atlas #14 now merged):
+- Aria  — issue #11 (directed reply UI)
 - Aria  — issue #16 (token usage display) → needs Atlas #15
 
 ## Last closed
 
-- #12 [Arch] Interaction mode switcher types — InteractionModeConfig added
-- #14 [Arch] Directed reply routing types — ChainStep, AutoChainConfig, chainConfig on SendMessageOptions
-- #15 [Arch] Token usage tracking types — SessionTokenUsage, getSessionTokenUsage() on ConversationStore
+- #14 [Atlas] Directed reply routing — sendMessage() now supports three routing modes
 
 ## Decisions made this session
 
-- Arch issues #12+#14+#15 batched into single PR (all additive, no conflicts)
-- Atlas review caught missing chainConfig on SendMessageOptions — fixed before merge
-- ChainStep.appendToContext controls context-feeding in auto-chain sequencer
-- AutoChainConfig.maxPasses is the loop-termination guard for Atlas
-- getSessionTokenUsage() returns SessionTokenUsage[] — Atlas aggregates, Vault implements, Aria reads
+- sendMessage() mode priority: chainConfig > targetModelId > parallel broadcast
+- Auto-chain: appendToContext=true steps accumulate into sharedMessages; false steps run against frozen context
+- Inactive model in directed/chain mode: emits synthetic error StreamChunk, chain continues (no halt)
+- collectingChunkHandler wraps onChunk to capture response text for context injection without blocking UI streaming
+- Pre-existing UI changes on branch left unstaged — Atlas boundary rule
 
 ## Gotchas
 

--- a/src/models/sendMessage.ts
+++ b/src/models/sendMessage.ts
@@ -1,16 +1,23 @@
 /**
  * Atlas — sendMessage.ts
  *
- * Top-level SendMessageFn implementation. Fans out to all active ModelProviders
- * in parallel and streams each model's response via onChunk.
+ * Top-level SendMessageFn implementation. Supports three routing modes:
  *
- * Parallel broadcast guarantees (issue #7):
- *   - All active providers fire simultaneously (no sequencing)
- *   - Each provider's stream is fully independent — one failure never
- *     cancels or delays another provider's stream
- *   - If a provider throws unexpectedly (outside its own error handling),
- *     a synthetic error StreamChunk is emitted and the broadcast continues
- *   - Resolves only when every provider has completed (success or error)
+ * 1. Parallel broadcast (default, issue #7):
+ *    No targetModelId, no chainConfig — all active providers fire simultaneously.
+ *    One failure never cancels or delays another provider's stream.
+ *    Resolves only when every provider has completed (success or error).
+ *
+ * 2. Directed reply (issue #14):
+ *    targetModelId is set — route to that single model only.
+ *    Active-model guard still applies (model must be active in the conversation).
+ *
+ * 3. Auto-chain (issue #14):
+ *    chainConfig is set — execute ChainStep[] in sequence (up to maxPasses times).
+ *    When a step's appendToContext is true, the model's full response is appended
+ *    to the shared message history before the next step runs, so each subsequent
+ *    model sees all prior responses in context.
+ *    When appendToContext is false, the step runs against the original context only.
  *
  * Aria calls this function; it is the primary public surface of /src/models.
  */
@@ -20,6 +27,7 @@ import type {
   StreamHandler,
   StreamChunk,
   Conversation,
+  Message,
   ModelId,
 } from '@/types';
 import { claudeProvider } from './claude';
@@ -28,11 +36,14 @@ import { gpt55Provider } from './gpt';
 // Registry of all active providers — extend when new providers are added.
 const PROVIDERS = [claudeProvider, gpt55Provider];
 
+// Internal provider type alias for clarity
+type Provider = typeof PROVIDERS[number];
+
 /**
  * Given a conversation, return providers whose modelId is active in the
  * conversation's model list.
  */
-function getActiveProviders(conversation: Conversation) {
+function getActiveProviders(conversation: Conversation): Provider[] {
   const activeIds = new Set(
     conversation.models.filter((m) => m.isActive).map((m) => m.modelId)
   );
@@ -51,8 +62,8 @@ function getActiveProviders(conversation: Conversation) {
  * guaranteed to see every provider reach completion.
  */
 async function runProviderIsolated(
-  provider: (typeof PROVIDERS)[number],
-  messages: Parameters<(typeof PROVIDERS)[number]['sendMessage']>[0],
+  provider: Provider,
+  messages: Message[],
   systemPrompt: string | undefined,
   onChunk: StreamHandler
 ): Promise<void> {
@@ -78,17 +89,169 @@ async function runProviderIsolated(
 }
 
 /**
- * SendMessageFn — fans out to all active providers in parallel.
+ * Wrap onChunk to accumulate streamed text for a specific model.
+ * The original onChunk still fires for every chunk (UI keeps streaming).
+ * getText() returns the full accumulated response once the provider is done.
+ */
+function collectingChunkHandler(
+  modelId: ModelId,
+  onChunk: StreamHandler
+): { handler: StreamHandler; getText: () => string } {
+  let accumulated = '';
+  const handler: StreamHandler = (chunk) => {
+    if (chunk.modelId === modelId && !chunk.isDone && chunk.content) {
+      accumulated += chunk.content;
+    }
+    onChunk(chunk);
+  };
+  return { handler, getText: () => accumulated };
+}
+
+// ─── Routing modes ────────────────────────────────────────────────────────────
+
+/**
+ * Mode 1 — Parallel broadcast.
+ * Fans out to all active providers simultaneously.
+ */
+async function runParallel(
+  providers: Provider[],
+  messages: Message[],
+  systemPrompt: string | undefined,
+  onChunk: StreamHandler
+): Promise<void> {
+  // Fire all providers in parallel. Promise.allSettled ensures every provider
+  // runs to completion regardless of whether siblings succeed or fail.
+  await Promise.allSettled(
+    providers.map((provider) =>
+      runProviderIsolated(provider, messages, systemPrompt, onChunk)
+    )
+  );
+}
+
+/**
+ * Mode 2 — Directed reply.
+ * Routes to a single model (targetModelId). The model must be active.
+ * Emits a synthetic error chunk if the target is not active or not found.
+ */
+async function runDirected(
+  targetModelId: ModelId,
+  activeProviders: Provider[],
+  messages: Message[],
+  systemPrompt: string | undefined,
+  onChunk: StreamHandler
+): Promise<void> {
+  const target = activeProviders.find((p) => p.config.modelId === targetModelId);
+
+  if (!target) {
+    const errorChunk: StreamChunk = {
+      modelId: targetModelId,
+      content: '',
+      isDone: true,
+      error: {
+        code: 'unknown',
+        message: `Model "${targetModelId}" is not active in this conversation.`,
+      },
+    };
+    onChunk(errorChunk);
+    return;
+  }
+
+  await runProviderIsolated(target, messages, systemPrompt, onChunk);
+}
+
+/**
+ * Mode 3 — Auto-chain.
+ * Executes ChainStep[] in order, up to chainConfig.maxPasses times.
+ * When a step has appendToContext=true, the model's response text is appended
+ * to the shared context before the next step executes.
+ *
+ * Active-model guard: steps referencing inactive models emit a synthetic error
+ * chunk and continue the chain (they do not append to context).
+ */
+async function runAutoChain(
+  options: SendMessageOptions & { conversation?: Conversation; systemPrompt?: string },
+  initialMessages: Message[],
+  onChunk: StreamHandler
+): Promise<void> {
+  const { chainConfig, conversation, systemPrompt } = options;
+  if (!chainConfig) return;
+
+  const { steps, maxPasses } = chainConfig;
+  if (steps.length === 0 || maxPasses < 1) return;
+
+  const activeProviders = conversation ? getActiveProviders(conversation) : PROVIDERS;
+
+  // Shared context that grows as appendToContext steps complete.
+  let sharedMessages: Message[] = [...initialMessages];
+
+  for (let pass = 0; pass < maxPasses; pass++) {
+    for (const step of steps) {
+      const provider = activeProviders.find((p) => p.config.modelId === step.modelId);
+
+      if (!provider) {
+        // Model inactive — emit error chunk and skip (do not halt the chain).
+        const errorChunk: StreamChunk = {
+          modelId: step.modelId,
+          content: '',
+          isDone: true,
+          error: {
+            code: 'unknown',
+            message: `Chain step ${step.stepIndex}: model "${step.modelId}" is not active.`,
+          },
+        };
+        onChunk(errorChunk);
+        continue;
+      }
+
+      if (step.appendToContext) {
+        // Wrap onChunk to accumulate the full response text for this step.
+        const { handler, getText } = collectingChunkHandler(step.modelId, onChunk);
+        await runProviderIsolated(provider, sharedMessages, systemPrompt, handler);
+
+        // Append the model's response as an assistant message for subsequent steps.
+        const responseText = getText();
+        if (responseText) {
+          sharedMessages = [
+            ...sharedMessages,
+            {
+              id: crypto.randomUUID(),
+              role: 'assistant' as const,
+              content: responseText,
+              modelId: step.modelId,
+              timestamp: Date.now(),
+            },
+          ];
+        }
+      } else {
+        // Run in isolation against current context — do not extend shared context.
+        await runProviderIsolated(provider, sharedMessages, systemPrompt, onChunk);
+      }
+    }
+  }
+}
+
+// ─── SendMessageFn ────────────────────────────────────────────────────────────
+
+/**
+ * SendMessageFn — routes to the appropriate mode based on options.
+ *
+ * - chainConfig set → auto-chain mode (sequential, context-feeding)
+ * - targetModelId set → directed mode (single model)
+ * - neither set → parallel broadcast mode (all active models)
  *
  * Each provider streams incremental chunks back via onChunk independently.
- * One model's failure (including unexpected throws) never blocks or cancels
- * the other models' streams. Resolves when all providers have completed.
+ * Resolves when the chosen mode has completed all provider calls.
  *
  * Usage by Aria:
  *   import { sendMessage } from '@/models';
+ *   // Parallel:
  *   await sendMessage({ conversationId, content }, onChunk);
+ *   // Directed:
+ *   await sendMessage({ conversationId, content, targetModelId: 'claude' }, onChunk);
+ *   // Auto-chain:
+ *   await sendMessage({ conversationId, content, chainConfig: { steps, maxPasses: 1 } }, onChunk);
  *
- * Note: This overload accepts an optional conversation parameter so callers
+ * Note: The extended signature accepts an optional conversation parameter so callers
  * can scope active providers to a specific conversation. If omitted, all
  * registered providers are used.
  */
@@ -96,16 +259,14 @@ export async function sendMessage(
   options: SendMessageOptions & { conversation?: Conversation; systemPrompt?: string },
   onChunk: StreamHandler
 ): Promise<void> {
-  const { conversation, systemPrompt, content } = options;
+  const { conversation, systemPrompt, content, targetModelId, chainConfig } = options;
 
-  const providers = conversation ? getActiveProviders(conversation) : PROVIDERS;
-
-  if (providers.length === 0) return;
+  const activeProviders = conversation ? getActiveProviders(conversation) : PROVIDERS;
 
   // Build message history from the conversation, if provided.
   // The current user message is appended at the end.
   const history = conversation?.messages ?? [];
-  const messages = [
+  const messages: Message[] = [
     ...history,
     {
       id: crypto.randomUUID(),
@@ -115,14 +276,27 @@ export async function sendMessage(
     },
   ];
 
-  // Fire all providers in parallel. Promise.allSettled ensures every provider
-  // runs to completion regardless of whether siblings succeed or fail.
-  // runProviderIsolated never rejects, so allSettled is defensive redundancy.
-  await Promise.allSettled(
-    providers.map((provider) =>
-      runProviderIsolated(provider, messages, systemPrompt, onChunk)
-    )
-  );
+  // ── Mode selection ──────────────────────────────────────────────────────────
+
+  // Auto-chain takes precedence — if chainConfig is supplied, sequence the steps.
+  if (chainConfig) {
+    await runAutoChain(
+      { ...options, conversation, systemPrompt },
+      messages,
+      onChunk
+    );
+    return;
+  }
+
+  // Directed reply — route to a single model.
+  if (targetModelId) {
+    await runDirected(targetModelId, activeProviders, messages, systemPrompt, onChunk);
+    return;
+  }
+
+  // Default — parallel broadcast.
+  if (activeProviders.length === 0) return;
+  await runParallel(activeProviders, messages, systemPrompt, onChunk);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `sendMessage()` now supports three routing modes, selected by priority: **auto-chain** (`chainConfig` set) > **directed reply** (`targetModelId` set) > **parallel broadcast** (default)
- Directed mode routes to a single active model; emits a synthetic error `StreamChunk` if the target is not active
- Auto-chain executes `ChainStep[]` in sequence up to `maxPasses` times; steps with `appendToContext: true` feed their full response text into the shared message context before the next step runs; steps with `appendToContext: false` run against the frozen context
- All routing logic lives entirely within `/src/models/sendMessage.ts` — no UI changes, no type changes
- `collectingChunkHandler` wraps `onChunk` to accumulate response text for context injection without blocking live streaming to the UI
- Inactive model in directed or chain mode emits a synthetic error chunk and the chain continues (no halt)

## Test plan

- [ ] Parallel broadcast: send with no `targetModelId`/`chainConfig` — both models respond
- [ ] Directed reply: send with `targetModelId: 'claude'` — only Claude responds
- [ ] Directed reply to inactive model: emits error chunk with `code: 'unknown'`
- [ ] Auto-chain single pass, `appendToContext: true` on first step: second model's request history includes first model's response as an assistant message
- [ ] Auto-chain single pass, `appendToContext: false`: second model receives only the original user message
- [ ] Auto-chain `maxPasses: 2`: each step fires twice in order
- [ ] Auto-chain with inactive step model: error chunk emitted, chain continues to next step

🤖 Generated with [Claude Code](https://claude.com/claude-code)