### PR TITLE
[Aria] Interaction mode switcher — #12

### DIFF
--- a/_system/HANDOFF.md
+++ b/_system/HANDOFF.md
@@ -6,12 +6,9 @@ Phase 2 — IN PROGRESS
 
 ## Active agents for next session
 
-All agents unblocked after Arch PR #31 merged.
-
 Parallel track A (no dependencies):
 - Atlas — issue #14 (directed reply routing)
 - Atlas — issue #15 (token usage tracking)
-- Aria  — issue #12 (interaction mode switcher)
 - Aria  — issue #13 (per-model system prompt UI)
 
 Parallel track B (depends on Atlas shipping first):
@@ -20,17 +17,15 @@ Parallel track B (depends on Atlas shipping first):
 
 ## Last closed
 
-- #12 [Arch] Interaction mode switcher types — InteractionModeConfig added
-- #14 [Arch] Directed reply routing types — ChainStep, AutoChainConfig, chainConfig on SendMessageOptions
-- #15 [Arch] Token usage tracking types — SessionTokenUsage, getSessionTokenUsage() on ConversationStore
+- #12 [Aria] Interaction mode switcher UI — InteractionModeSwitcher component (this session)
 
 ## Decisions made this session
 
-- Arch issues #12+#14+#15 batched into single PR (all additive, no conflicts)
-- Atlas review caught missing chainConfig on SendMessageOptions — fixed before merge
-- ChainStep.appendToContext controls context-feeding in auto-chain sequencer
-- AutoChainConfig.maxPasses is the loop-termination guard for Atlas
-- getSessionTokenUsage() returns SessionTokenUsage[] — Atlas aggregates, Vault implements, Aria reads
+- InteractionModeSwitcher is a segmented radiogroup (pill buttons) placed to
+  the right of the ModelSelectorPanel trigger chip in AppLayout bottom strip
+- Mode is persisted per conversation: onModeChange → setConversations in App.tsx
+- Tooltip uses group-hover pattern consistent with ghost mode tooltip in InputBar
+- INTERACTION_MODES registry (InteractionModeConfig[]) lives in the component file
 
 ## Gotchas
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Conversation, Message, ModelConfig, ModelId } from '@/types';
+import type { Conversation, InteractionMode, Message, ModelConfig, ModelId } from '@/types';
 import { AppLayout } from '@/ui/AppLayout';
 
 // ─── Mock Data ────────────────────────────────────────────────────────────────
@@ -164,6 +164,17 @@ export default function App() {
     );
   };
 
+  /** Persists the chosen interaction mode on the active conversation. */
+  const handleModeChange = (mode: InteractionMode) => {
+    setConversations((prev) =>
+      prev.map((conv) =>
+        conv.id === activeConversationId
+          ? { ...conv, interactionMode: mode, updatedAt: Date.now() }
+          : conv,
+      ),
+    );
+  };
+
   return (
     <AppLayout
       conversations={conversations}
@@ -178,6 +189,8 @@ export default function App() {
       onNewConversation={handleNewConversation}
       onToggleModel={handleToggleModel}
       onAddModel={handleAddModel}
+      activeMode={activeConversation?.interactionMode ?? 'parallel'}
+      onModeChange={handleModeChange}
     />
   );
 }

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -1,6 +1,7 @@
-import type { Conversation, Message, ModelConfig, ModelId } from '@/types';
+import type { Conversation, InteractionMode, Message, ModelConfig, ModelId } from '@/types';
 import { MessageThread } from './MessageThread';
 import { InputBar } from './InputBar';
+import { InteractionModeSwitcher } from './InteractionModeSwitcher';
 import { Sidebar } from './Sidebar';
 import { ModelSelectorPanel } from './ModelSelectorPanel';
 
@@ -21,6 +22,10 @@ interface AppLayoutProps {
   onToggleModel: (modelId: ModelId) => void;
   /** Called when user adds an inactive model back into the active set. */
   onAddModel: (modelId: ModelId) => void;
+  /** Current interaction mode for the active conversation. */
+  activeMode: InteractionMode;
+  /** Called when the user switches interaction modes. Parent persists the change. */
+  onModeChange: (mode: InteractionMode) => void;
 }
 
 export function AppLayout({
@@ -37,6 +42,8 @@ export function AppLayout({
   onRetry,
   onToggleModel,
   onAddModel,
+  activeMode,
+  onModeChange,
 }: AppLayoutProps) {
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-bg">
@@ -57,14 +64,23 @@ export function AppLayout({
           onRetry={onRetry}
         />
 
-        {/* Bottom section: model selector + input bar */}
+        {/* Bottom section: model selector + mode switcher + input bar */}
         <div className="flex-shrink-0 px-4 pb-0">
-          {/* Model selector panel — slides up above the input bar */}
-          <ModelSelectorPanel
-            models={allModels}
-            onToggleModel={onToggleModel}
-            onAddModel={onAddModel}
-          />
+          {/* Row: model selector trigger (left) + mode switcher (right) */}
+          <div className="flex items-end justify-between">
+            <ModelSelectorPanel
+              models={allModels}
+              onToggleModel={onToggleModel}
+              onAddModel={onAddModel}
+            />
+            {/* Interaction mode switcher — persisted per conversation via onModeChange */}
+            <div className="mb-2 flex-shrink-0">
+              <InteractionModeSwitcher
+                activeMode={activeMode}
+                onModeChange={onModeChange}
+              />
+            </div>
+          </div>
         </div>
 
         {/* Input bar — fixed at bottom of main area */}

--- a/src/ui/InteractionModeSwitcher.tsx
+++ b/src/ui/InteractionModeSwitcher.tsx
@@ -1,0 +1,124 @@
+import type { InteractionMode, InteractionModeConfig } from '@/types';
+
+// ─── Mode registry ────────────────────────────────────────────────────────────
+
+/**
+ * Typed registry of all supported interaction modes.
+ * Drives the switcher UI and tooltip copy.
+ */
+const INTERACTION_MODES: InteractionModeConfig[] = [
+  {
+    mode: 'parallel',
+    label: 'Parallel',
+    description: 'All active models respond simultaneously to every message.',
+  },
+  {
+    mode: 'manual',
+    label: 'Manual',
+    description: 'You choose which model to send each message to.',
+  },
+  {
+    mode: 'auto-chain',
+    label: 'Auto-chain',
+    description: 'Models respond in sequence, each building on the previous reply.',
+  },
+];
+
+// ─── ModeButton ───────────────────────────────────────────────────────────────
+
+interface ModeButtonProps {
+  config: InteractionModeConfig;
+  isSelected: boolean;
+  onSelect: (mode: InteractionMode) => void;
+}
+
+function ModeButton({ config, isSelected, onSelect }: ModeButtonProps) {
+  return (
+    <div className="relative group">
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        aria-label={`${config.label} — ${config.description}`}
+        onClick={() => onSelect(config.mode)}
+        className={[
+          'relative h-7 px-3 rounded-full',
+          'text-[12px] font-medium',
+          'border',
+          'transition-[background-color,border-color,color] duration-fast',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2',
+          'cursor-pointer select-none whitespace-nowrap',
+          isSelected
+            ? 'bg-hover border-border text-text-primary'
+            : 'bg-transparent border-transparent text-text-muted hover:text-text-secondary hover:border-border-subtle',
+        ].join(' ')}
+      >
+        {config.label}
+      </button>
+
+      {/* Tooltip — shown on hover via group */}
+      <div
+        role="tooltip"
+        className={[
+          'absolute bottom-full left-1/2 -translate-x-1/2 mb-2',
+          'w-max max-w-[200px]',
+          'bg-sidebar border border-border rounded-sm shadow-md',
+          'px-3 py-2 text-[11px] leading-[1.4] text-text-primary',
+          'pointer-events-none',
+          'opacity-0 group-hover:opacity-100',
+          // Respect prefers-reduced-motion — see global CSS
+          'transition-opacity duration-fast',
+          'z-20',
+        ].join(' ')}
+      >
+        {config.description}
+        {/* Caret */}
+        <span
+          className="absolute top-full left-1/2 -translate-x-1/2 -mt-px"
+          aria-hidden="true"
+          style={{
+            borderLeft: '5px solid transparent',
+            borderRight: '5px solid transparent',
+            borderTop: '5px solid var(--border-default)',
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── InteractionModeSwitcher ──────────────────────────────────────────────────
+
+export interface InteractionModeSwitcherProps {
+  /** Currently active interaction mode for the conversation. */
+  activeMode: InteractionMode;
+  /** Called when the user selects a different mode. Parent persists the change. */
+  onModeChange: (mode: InteractionMode) => void;
+}
+
+/**
+ * Segmented radio group for switching between Parallel / Manual / Auto-chain.
+ * Reads from the `INTERACTION_MODES` registry for labels and tooltip descriptions.
+ * Place above the InputBar in AppLayout (e.g. in the bottom controls strip).
+ */
+export function InteractionModeSwitcher({
+  activeMode,
+  onModeChange,
+}: InteractionModeSwitcherProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Interaction mode"
+      className="inline-flex items-center gap-[2px] p-[3px] rounded-full bg-sidebar border border-border-subtle"
+    >
+      {INTERACTION_MODES.map((config) => (
+        <ModeButton
+          key={config.mode}
+          config={config}
+          isSelected={activeMode === config.mode}
+          onSelect={onModeChange}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/ui/InteractionModeSwitcher.tsx
+++ b/src/ui/InteractionModeSwitcher.tsx
@@ -74,13 +74,8 @@ function ModeButton({ config, isSelected, onSelect }: ModeButtonProps) {
         {config.description}
         {/* Caret */}
         <span
-          className="absolute top-full left-1/2 -translate-x-1/2 -mt-px"
+          className="absolute top-full left-1/2 -translate-x-1/2 -mt-px block border-l-[5px] border-r-[5px] border-t-[5px] border-l-transparent border-r-transparent border-t-border"
           aria-hidden="true"
-          style={{
-            borderLeft: '5px solid transparent',
-            borderRight: '5px solid transparent',
-            borderTop: '5px solid var(--border-default)',
-          }}
         />
       </div>
     </div>

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -2,6 +2,7 @@
 
 export { AppLayout } from './AppLayout';
 export { InputBar } from './InputBar';
+export { InteractionModeSwitcher } from './InteractionModeSwitcher';
 export { MessageBubble } from './MessageBubble';
 export { MessageThread } from './MessageThread';
 export { ModelSelectorPanel } from './ModelSelectorPanel';


### PR DESCRIPTION
## Summary

- Adds `InteractionModeSwitcher` component (`/src/ui/InteractionModeSwitcher.tsx`) — a segmented `radiogroup` with Parallel / Manual / Auto-chain pill buttons
- Driven by a typed `INTERACTION_MODES: InteractionModeConfig[]` registry (label + description per mode)
- Tooltip on each button uses the `description` field from the registry, shown via `group-hover` (consistent with existing ghost mode tooltip pattern)
- Mode is persisted per conversation: `onModeChange` prop threads through `AppLayout` → `App.tsx` → `setConversations`
- Switcher is placed to the right of the ModelSelectorPanel trigger chip in the bottom controls strip
- Transitions use `duration-fast` (`transition-[background-color,border-color,color]`); tooltip fade respects `prefers-reduced-motion` via global CSS
- `npm run lint` and `npm run build` both pass

## Files changed

- `src/ui/InteractionModeSwitcher.tsx` — new component
- `src/ui/AppLayout.tsx` — adds `activeMode` + `onModeChange` props, places switcher in layout
- `src/ui/index.ts` — exports `InteractionModeSwitcher`
- `src/App.tsx` — wires `handleModeChange` and passes `activeMode` down
- `_system/HANDOFF.md` — updated

## No new dependencies

## Test plan
- [ ] Switcher renders with three buttons (Parallel, Manual, Auto-chain)
- [ ] Active mode button shows filled/bordered style; others show muted/transparent
- [ ] Clicking a button calls `onModeChange` with the correct `InteractionMode` value
- [ ] Tooltip appears on hover of each button containing the mode description
- [ ] Switching conversations resets the switcher to that conversation's saved mode
- [ ] `prefers-reduced-motion` suppresses tooltip fade (instant show/hide)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)