### PR TITLE
feat(types): ModelVersionOption + selectedVersionId for model version selection (#61)

### DIFF
--- a/_system/HANDOFF.md
+++ b/_system/HANDOFF.md
@@ -7,26 +7,24 @@ Accessibility baseline audit complete.
 
 ## Last closed
 
-- #45 (Ada): Phase 4 accessibility baseline audit. 147 new tests (contrast ratios
-  + keyboard logic patterns). 13 contrast failures documented as it.fails() tests
-  tracking real token issues. 23 findings: 0 critical, 9 serious/moderate UI
-  findings (A1–A9), 11 contrast failures across 5 themes (B1–B13), 3 minor (C1–C3).
-  15 GitHub issues opened (#46–#60 — 12 for Aria, 3 for Luma).
+- #61 (Arch): Model version selection types. Added `ModelVersionOption` interface
+  and `selectedVersionId?: string` to `ModelConfig`. PR open on
+  `61-arch-model-version-types`. Awaiting user authorization to merge.
 
 ## In progress
 
-None. All known branches merged.
+- #61 (Arch): Branch `61-arch-model-version-types` — PR open, not yet merged.
 
 ## Decisions made this session
 
-- a11y test files live in src/tests/a11y/{themes,keyboard,components,audit-reports}.
-- Contrast tests use pure TypeScript math (no jsdom needed) — run in vitest baseline.
-- Keyboard tests verify interaction logic contracts, not DOM rendering.
-- Component axe-core tests blocked on @testing-library/react + jsdom installation
-  (HANDOFF priority #1 — Scout's domain).
-- it.fails() wrappers document known token failures; removal signals Luma fix merged.
-- Accent colors (deepseek, gemini) used as text labels — 4.5:1 threshold applies
-  (12px/11px are NOT large text per WCAG).
+- `getAvailableVersions()` does NOT go on `ModelProvider`. Available versions are
+  static; they belong on MODEL_REGISTRY entries in Atlas. Rationale documented in
+  JSDoc on `ModelVersionOption`.
+- `selectedVersionId` is optional on `ModelConfig`. Absence = use provider default.
+  Atlas must handle the undefined case in sendMessage.
+- `ModelVersionOption.id` is the exact API-level model string (not a typed union) —
+  Atlas controls the allowed values in its registry. Keeping it `string` avoids
+  requiring a types PR every time Atlas adds a new version.
 
 ## Model providers (all on main)
 
@@ -38,6 +36,19 @@ None. All known branches merged.
 | Grok | no | accent-grok | xAI |
 | DeepSeek | no | accent-deepseek | DeepSeek |
 | Mistral | no | accent-mistral | Mistral |
+
+## Next issues in priority order
+
+1. #61 Atlas: add `availableVersions: ModelVersionOption[]` to each MODEL_REGISTRY entry; read `selectedVersionId` from ModelConfig in sendMessage
+2. #61 Gate: persist `selectedVersionId` on ModelConfig to/from localStorage; expose setter to Aria
+3. #61 Aria: render version picker in per-model settings panel
+4. #62 (Aria + Gate): Resizable sidebar — self-contained, can run anytime
+5. Install @testing-library/react + jsdom so Scout can test React hook layer and Ada can run axe-core component tests
+6. Aria: fix A1 (MessageBubble Reply button aria-hidden — #46)
+7. Aria: fix A2 (ModelSelectorPanel aria-controls id mismatch — #47)
+8. Luma: fix text-muted contrast failures (#58)
+9. Luma: fix accent-deepseek text contrast failures (#60)
+10. Aria: remaining a11y issues #48–#57
 
 ## Gotchas
 
@@ -56,15 +67,3 @@ None. All known branches merged.
   + jsdom before it can be integration-tested; neither is in devDependencies.
 - accent-deepseek in Slate and Ash is a serious text contrast failure (3.32:1 and
   3.26:1 on card) — Luma fix tracked in gh issue #60.
-
-## Next issues in priority order
-
-1. #61 (Arch → Atlas + Gate → Aria): Model version selection per provider — Arch types first, then parallel Atlas/Gate, then Aria UI
-2. #62 (Aria + Gate): Resizable sidebar — self-contained, can run anytime
-3. Install @testing-library/react + jsdom so Scout can test React hook layer and Ada can run axe-core component tests (src/tests/a11y/components/)
-4. Aria: fix A1 (MessageBubble Reply button aria-hidden — #46) — blocks keyboard users
-5. Aria: fix A2 (ModelSelectorPanel aria-controls id mismatch — #47)
-6. Luma: fix text-muted contrast failures (#58) — 5 themes affected
-7. Luma: fix accent-deepseek text contrast failures (#60) — Slate and Ash most severe
-8. Aria: remaining a11y issues #48–#57 (streaming live regions, focus management, etc.)
-9. Regression test suite for known bugs as they are fixed.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,6 +99,37 @@ export interface Message {
   error?: ModelError;
 }
 
+// ─── Model version selection ───────────────────────────────────────────────────
+
+/**
+ * A single selectable version of a model, surfaced in the model config panel.
+ *
+ * Atlas populates these on each ModelRegistryEntry. Aria renders them as a
+ * version picker control inside the per-model settings panel. Gate persists the
+ * user's selection via `selectedVersionId` on `ModelConfig`.
+ *
+ * `id` must be the exact API-level model string passed to the provider endpoint
+ * (e.g. "claude-opus-4-5", "gpt-4o", "gemini-2.5-pro"). `displayName` is the
+ * human-readable label shown in the picker. `description` is an optional
+ * one-liner surfaced as a subtitle or tooltip.
+ *
+ * Design note: available versions are static (known at build time). This type
+ * therefore lives on the MODEL_REGISTRY entry in Atlas, NOT on `ModelProvider`.
+ * Adding `getAvailableVersions()` to `ModelProvider` would force every runtime
+ * provider instance to carry static data it has no business owning, and would
+ * complicate mocking in tests. If a future provider needs dynamic version
+ * discovery (e.g. fetching from a versions endpoint), surface that as a
+ * separate interface at that time — do not extend ModelProvider prematurely.
+ */
+export interface ModelVersionOption {
+  /** API-level model string, e.g. "claude-opus-4-5", "gpt-4o". */
+  id: string;
+  /** Human-readable label shown in the version picker, e.g. "Claude Opus 4". */
+  displayName: string;
+  /** Optional one-liner shown as subtitle or tooltip, e.g. "Most capable". */
+  description?: string;
+}
+
 // ─── Model config ─────────────────────────────────────────────────────────────
 
 export interface ModelConfig {
@@ -110,6 +141,16 @@ export interface ModelConfig {
   /** Phase 2 — per-model system prompt. */
   systemPrompt?: string;
   isActive: boolean;
+  /**
+   * The `id` of the `ModelVersionOption` the user has selected for this model.
+   * Absence means "use the provider's default version" (i.e. whatever Atlas
+   * sends when no explicit model string override is applied).
+   *
+   * Gate reads and writes this field. Atlas reads it in `sendMessage` to choose
+   * which API model string to pass to the provider endpoint. Aria reads it to
+   * highlight the active option in the version picker.
+   */
+  selectedVersionId?: string;
 }
 
 // ─── Conversation ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Types added

### `ModelVersionOption` (new interface)

```ts
export interface ModelVersionOption {
  id: string;           // exact API-level model string, e.g. "claude-opus-4-5", "gpt-4o"
  displayName: string;  // human-readable label, e.g. "Claude Opus 4"
  description?: string; // optional subtitle/tooltip, e.g. "Most capable"
}
```

### `ModelConfig` (extended)

Added one optional field:

```ts
selectedVersionId?: string;
```

Absence means "use the provider's default" — Atlas must handle `undefined` gracefully in `sendMessage`.

---

## Design decisions

### Why `getAvailableVersions()` is NOT on `ModelProvider`

Available versions are static — known at build time, not discovered at runtime. The `MODEL_REGISTRY` in `/src/models/registry.ts` already holds all static per-model data (this is the established Atlas pattern). Putting `getAvailableVersions()` on `ModelProvider` would:

1. Force every runtime provider instance to carry a list of strings it has no business owning.
2. Complicate test mocking (every mock provider needs a version list stub).
3. Conflate the runtime API boundary (`ModelProvider`) with the static catalog (`MODEL_REGISTRY`).

**Decision:** Atlas adds `availableVersions: ModelVersionOption[]` to each `MODEL_REGISTRY` entry. The field is defined using the `ModelVersionOption` type from this file. `ModelProvider` is unchanged.

If a future provider needs dynamic version discovery (e.g. a `/models` endpoint), that is a separate interface decision — not a premature extension of `ModelProvider`.

### Why `selectedVersionId` is `string` not a typed union

The set of valid version IDs is controlled entirely by Atlas's registry. Making it a typed union in `types/index.ts` would require a types PR every time Atlas adds a new model version — coupling Atlas's release cadence to Arch's review cycle. `string` is correct here; Atlas validates at the registry boundary.

### Why `selectedVersionId` lives on `ModelConfig` and not a new `ModelVersionConfig`

`ModelConfig` is the per-model config shape already used by Aria, Atlas, and Gate for active/inactive state and system prompts. Adding `selectedVersionId` here keeps the version selection co-located with the other user-configurable per-model preferences. A separate `ModelVersionConfig` would fragment what is conceptually one record.

---

## Downstream: what each agent must do

### Atlas
- Add `availableVersions: ModelVersionOption[]` to each entry in `MODEL_REGISTRY` (in `/src/models/registry.ts`). Populate with the real API model strings and display names for each provider.
- In `sendMessage` (or the per-provider `ModelProvider.sendMessage`), read `config.selectedVersionId` from the active `ModelConfig`. If present, use it as the API model string. If absent, fall back to the provider's current hard-coded default.

### Gate
- When persisting `ModelConfig` to localStorage, include `selectedVersionId` in the serialized shape.
- Expose a setter — e.g. `setModelVersion(modelId: ModelId, versionId: string) => void` — that Aria can call when the user selects a version. Validate that `versionId` is non-empty before writing.
- When loading `ModelConfig` from localStorage, treat a missing `selectedVersionId` as `undefined` (no migration needed — new field is optional).

### Aria
- In the per-model settings panel, read `availableVersions` from the MODEL_REGISTRY entry for the model (via the Atlas cross-agent utility exception, same pattern as `buildDefaultModelConfigs`).
- Render a version picker (select or radio group). Highlight the option whose `id === modelConfig.selectedVersionId`.
- On selection, call Gate's setter. Aria does not write to `ModelConfig` directly.

---

## Collision check

No other Arch branch was open when this work began. The three stale remote branches (`37-arch-theme-accents-wave2`, `phase4-arch-deepseek-mistral-types`, `phase4-arch-expand-model-types`) are fully merged — verified via `git branch -a` before checkout.

## Lint and build

- `npm run lint` — passed (0 warnings)
- `npm run build` — passed (tsc + vite, 71 modules, no errors)