### PR TITLE
fix(#205 #210 #211 #212): focus ring audit + 600ms tooltip delay

### DIFF
--- a/src/ui/InputBar.tsx
+++ b/src/ui/InputBar.tsx
@@ -223,14 +223,23 @@ export function InputBar({
           'transition-[border-color] duration-fast',
         ].join(' ')}
       >
-        {/* Ghost mode indicator — left side, shown only when active */}
+        {/* Ghost mode indicator — left side, shown only when active.
+            tabIndex={0} makes this keyboard-reachable so screen reader users can
+            access the tooltip via focus. onFocus shows immediately (0ms per
+            tooltip.md §1); onBlur hides immediately. The title attribute is
+            omitted to prevent double-announcement alongside aria-describedby
+            (NVDA/Firefox double-reads both). */}
         {isGhostMode && (
           <div
-            className="flex-shrink-0 text-text-muted self-center relative"
-            title="Ghost mode — this conversation won't be saved"
+            className="flex-shrink-0 text-text-muted self-center relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1 rounded"
+            tabIndex={0}
+            aria-label="Ghost mode — this conversation won't be saved"
             aria-describedby={ghostTooltipId}
             onMouseEnter={handleGhostMouseEnter}
             onMouseLeave={handleGhostMouseLeave}
+            onFocus={() => setIsGhostTooltipVisible(true)}
+            onBlur={() => setIsGhostTooltipVisible(false)}
+            onKeyDown={(e) => { if (e.key === 'Escape') setIsGhostTooltipVisible(false); }}
           >
             <GhostIcon />
             {/* Tooltip — shown after 600ms hover delay per tooltip.md §1 (#210).

--- a/src/ui/InputBar.tsx
+++ b/src/ui/InputBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useId } from 'react';
 import type { ModelConfig } from '@/types';
 
 interface InputBarProps {
@@ -98,6 +98,26 @@ export function InputBar({
   const [value, setValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isFocused, setIsFocused] = useState(false);
+
+  // Ghost mode tooltip — 600ms hover delay per tooltip.md §1 (#210).
+  // Hover shows after intentionality delay; focus shows immediately.
+  const [isGhostTooltipVisible, setIsGhostTooltipVisible] = useState(false);
+  const ghostHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const ghostTooltipId = useId();
+
+  const handleGhostMouseEnter = useCallback(() => {
+    ghostHoverTimerRef.current = setTimeout(() => {
+      setIsGhostTooltipVisible(true);
+    }, 600);
+  }, []);
+
+  const handleGhostMouseLeave = useCallback(() => {
+    if (ghostHoverTimerRef.current !== null) {
+      clearTimeout(ghostHoverTimerRef.current);
+      ghostHoverTimerRef.current = null;
+    }
+    setIsGhostTooltipVisible(false);
+  }, []);
 
   const isEmpty = value.trim().length === 0;
   // §3.3: gate on zero active models in addition to the streaming/empty checks.
@@ -206,22 +226,36 @@ export function InputBar({
         {/* Ghost mode indicator — left side, shown only when active */}
         {isGhostMode && (
           <div
-            className="flex-shrink-0 text-text-muted self-center relative group"
+            className="flex-shrink-0 text-text-muted self-center relative"
             title="Ghost mode — this conversation won't be saved"
+            aria-describedby={ghostTooltipId}
+            onMouseEnter={handleGhostMouseEnter}
+            onMouseLeave={handleGhostMouseLeave}
           >
             <GhostIcon />
-            {/* Tooltip */}
+            {/* Tooltip — shown after 600ms hover delay per tooltip.md §1 (#210).
+                Always in DOM so aria-describedby reference is never broken.
+                Opacity controlled by JS state rather than CSS group-hover to
+                enable the intentionality delay. */}
             <div
+              id={ghostTooltipId}
+              role="tooltip"
               className={[
                 'absolute bottom-full left-0 mb-2',
                 'bg-sidebar border border-border rounded-sm',
-                'px-3 py-2 text-[10px] text-text-primary whitespace-nowrap',
-                'pointer-events-none opacity-0 group-hover:opacity-100',
+                'px-3 py-2 text-[11px] leading-[1.4] text-text-primary whitespace-nowrap',
+                'pointer-events-none',
                 'transition-opacity duration-fast',
+                'z-20',
+                isGhostTooltipVisible ? 'opacity-100' : 'opacity-0',
               ].join(' ')}
-              role="tooltip"
             >
               Ghost mode — this conversation won't be saved
+              {/* Caret */}
+              <span
+                className="absolute top-full left-3 -mt-px block border-l-[5px] border-r-[5px] border-t-[5px] border-l-transparent border-r-transparent border-t-border"
+                aria-hidden="true"
+              />
             </div>
           </div>
         )}

--- a/src/ui/InteractionModeSwitcher.tsx
+++ b/src/ui/InteractionModeSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useCallback } from 'react';
 import type { InteractionMode, InteractionModeConfig } from '@/types';
 
 // ─── Mode registry ────────────────────────────────────────────────────────────
@@ -83,6 +84,48 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
     ? 'Coming soon — not yet available'
     : config.description;
 
+  // ── Tooltip show/hide state with 600ms hover delay (#211) ────────────────
+  // Per tooltip.md §1: hover shows after 600ms (intentionality filter).
+  // Focus shows immediately (0ms delay). Both hide immediately on leave/blur.
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    hoverTimerRef.current = setTimeout(() => {
+      setIsTooltipVisible(true);
+    }, 600);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    setIsTooltipVisible(false);
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    // Cancel any pending hover timer — focus wins with immediate show.
+    if (hoverTimerRef.current !== null) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    setIsTooltipVisible(true);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    setIsTooltipVisible(false);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsTooltipVisible(false);
+      }
+    },
+    [],
+  );
+
   if (isDisabled) {
     // Render as a non-interactive span so it cannot be focused or activated.
     // aria-disabled is not used on a span (it only applies to interactive roles).
@@ -90,7 +133,11 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
     // is not needed here — the span is non-interactive and carries no role.
     // The "coming soon" text is conveyed visually via the tooltip on hover.
     return (
-      <div className="relative group">
+      <div
+        className="relative"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
         <span
           aria-hidden="false"
           aria-label={`${config.label} — coming soon`}
@@ -108,7 +155,7 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
           {config.label}
         </span>
 
-        {/* Tooltip — shown on hover via group */}
+        {/* Tooltip — shown after 600ms hover delay (tooltip.md §1) */}
         <div
           id={tooltipId}
           role="tooltip"
@@ -118,10 +165,11 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
             'bg-sidebar border border-border rounded-sm shadow-md',
             'px-3 py-2 text-[11px] leading-[1.4] text-text-primary',
             'pointer-events-none',
-            'opacity-0 group-hover:opacity-100',
-            // Respect prefers-reduced-motion — see global CSS
+            // Opacity controlled by JS state (not CSS group-hover) to allow
+            // the 600ms intentionality delay. Exit is instant per spec.
             'transition-opacity duration-fast',
             'z-20',
+            isTooltipVisible ? 'opacity-100' : 'opacity-0',
           ].join(' ')}
         >
           {tooltipContent}
@@ -136,7 +184,11 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
   }
 
   return (
-    <div className="relative group">
+    <div
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       <button
         type="button"
         role="radio"
@@ -144,6 +196,9 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
         aria-label={`${config.label} — ${config.description}`}
         aria-describedby={tooltipId}
         onClick={() => onSelect(config.mode)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
         className={[
           'relative h-7 px-3 rounded-full',
           'text-[12px] font-medium whitespace-nowrap',
@@ -159,7 +214,7 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
         {config.label}
       </button>
 
-      {/* Tooltip — shown on hover via group */}
+      {/* Tooltip — shown after 600ms hover delay or immediately on focus (tooltip.md §1) */}
       <div
         id={tooltipId}
         role="tooltip"
@@ -169,10 +224,11 @@ function ModeButton({ config, isSelected, onSelect, tooltipAlign = 'center' }: M
           'bg-sidebar border border-border rounded-sm shadow-md',
           'px-3 py-2 text-[11px] leading-[1.4] text-text-primary',
           'pointer-events-none',
-          'opacity-0 group-hover:opacity-100',
-          // Respect prefers-reduced-motion — see global CSS
+          // Opacity controlled by JS state (not CSS group-hover) to allow
+          // the 600ms intentionality delay. Exit is instant per spec.
           'transition-opacity duration-fast',
           'z-20',
+          isTooltipVisible ? 'opacity-100' : 'opacity-0',
         ].join(' ')}
       >
         {config.description}
@@ -211,6 +267,9 @@ export interface InteractionModeSwitcherProps {
  * spans with a "coming soon" tooltip. They cannot be selected. Only Parallel
  * is selectable. This reflects that App.tsx:handleSend always broadcasts in
  * parallel — the UI must not imply otherwise. (#131)
+ *
+ * Tooltip delay: all tooltips in this component use the 600ms hover
+ * intentionality filter per tooltip.md §1 (#211).
  */
 export function InteractionModeSwitcher({
   activeMode,

--- a/src/ui/ModelSelectorPanel.tsx
+++ b/src/ui/ModelSelectorPanel.tsx
@@ -359,7 +359,7 @@ function AddModelButton({ availableModels, onAdd }: AddModelButtonProps) {
                 'text-left cursor-pointer',
                 'hover:bg-hover',
                 'transition-colors duration-fast',
-                'focus-visible:outline-none focus-visible:bg-hover',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset focus-visible:bg-hover',
               ].join(' ')}
             >
               <span

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -423,7 +423,10 @@ function ThreadActionMenu({
               type="button"
               data-confirm="true"
               onClick={onClose}
-              className="flex-1 px-2 py-1 rounded text-text-secondary bg-hover hover:bg-hover/80 transition-colors duration-fast text-[11px]"
+              className={[
+                'flex-1 px-2 py-1 rounded text-text-secondary bg-hover hover:bg-hover/80 transition-colors duration-fast text-[11px]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+              ].join(' ')}
             >
               Cancel
             </button>
@@ -431,7 +434,10 @@ function ThreadActionMenu({
               type="button"
               data-confirm="true"
               onClick={() => { onDelete(); onClose(); }}
-              className="flex-1 px-2 py-1 rounded text-white bg-error-bg hover:opacity-90 transition-opacity duration-fast text-[11px]"
+              className={[
+                'flex-1 px-2 py-1 rounded text-white bg-error-bg hover:opacity-90 transition-opacity duration-fast text-[11px]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+              ].join(' ')}
             >
               Delete
             </button>
@@ -453,7 +459,7 @@ function ThreadActionMenu({
               'w-full px-2 py-1 rounded text-[12px]',
               'bg-input border border-border',
               'text-text-primary placeholder:text-text-muted',
-              'focus:outline-none focus:ring-1 focus:ring-focus',
+              'focus:outline-none focus-visible:ring-1 focus-visible:ring-focus',
             ].join(' ')}
           />
           {/* Existing group suggestions */}
@@ -464,7 +470,10 @@ function ThreadActionMenu({
                   <button
                     type="button"
                     onClick={() => { onSetGroup(g); onClose(); }}
-                    className="w-full text-left px-2 py-1 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast text-[11px] rounded"
+                    className={[
+                      'w-full text-left px-2 py-1 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast text-[11px] rounded',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+                    ].join(' ')}
                   >
                     {g}
                   </button>
@@ -476,14 +485,20 @@ function ThreadActionMenu({
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 px-2 py-1 rounded text-text-secondary bg-hover hover:bg-hover/80 transition-colors duration-fast text-[11px]"
+              className={[
+                'flex-1 px-2 py-1 rounded text-text-secondary bg-hover hover:bg-hover/80 transition-colors duration-fast text-[11px]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+              ].join(' ')}
             >
               Cancel
             </button>
             <button
               type="button"
               onClick={handleGroupConfirm}
-              className="flex-1 px-2 py-1 rounded text-text-primary bg-interactive-active hover:opacity-90 transition-opacity duration-fast text-[11px]"
+              className={[
+                'flex-1 px-2 py-1 rounded text-text-primary bg-interactive-active hover:opacity-90 transition-opacity duration-fast text-[11px]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+              ].join(' ')}
             >
               Confirm
             </button>
@@ -608,6 +623,7 @@ function ThreadRow({
           isChecked ? 'pl-8' : 'pl-[14px] group-hover:pl-8',
           'pr-8',
           'transition-all duration-fast',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset',
         ].join(' ')}
       >
         {/* Row 1: title + timestamp */}
@@ -759,6 +775,7 @@ function ArchiveToggle({ value, onChange }: ArchiveToggleProps) {
         onClick={() => onChange('active')}
         className={[
           'flex-1 py-1 text-center transition-colors duration-fast',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset',
           value === 'active'
             ? 'bg-hover text-text-primary'
             : 'text-text-muted hover:text-text-secondary hover:bg-hover/40',
@@ -772,6 +789,7 @@ function ArchiveToggle({ value, onChange }: ArchiveToggleProps) {
         onClick={() => onChange('archived')}
         className={[
           'flex-1 py-1 text-center transition-colors duration-fast',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset',
           value === 'archived'
             ? 'bg-hover text-text-primary'
             : 'text-text-muted hover:text-text-secondary hover:bg-hover/40',
@@ -859,7 +877,10 @@ function BulkActionBar({
         <button
           type="button"
           onClick={onDeselectAll}
-          className="text-[11px] text-text-muted hover:text-text-secondary transition-colors duration-fast"
+          className={[
+            'text-[11px] text-text-muted hover:text-text-secondary transition-colors duration-fast',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1 rounded',
+          ].join(' ')}
         >
           Clear
         </button>
@@ -875,6 +896,7 @@ function BulkActionBar({
               'flex-1 py-1 rounded text-[11px] text-center',
               'text-text-secondary bg-hover hover:bg-hover/80',
               'transition-colors duration-fast',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
             ].join(' ')}
           >
             Archive selected
@@ -887,6 +909,7 @@ function BulkActionBar({
               'flex-1 py-1 rounded text-[11px] text-center',
               'text-error bg-hover hover:bg-hover/80',
               'transition-colors duration-fast',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
             ].join(' ')}
           >
             Delete selected
@@ -903,14 +926,20 @@ function BulkActionBar({
               ref={confirmCancelRef}
               type="button"
               onClick={handleCancelConfirm}
-              className="flex-1 py-1 rounded text-[11px] text-text-secondary bg-hover hover:bg-hover/80 transition-colors duration-fast"
+              className={[
+                'flex-1 py-1 rounded text-[11px] text-text-secondary bg-hover hover:bg-hover/80 transition-colors duration-fast',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+              ].join(' ')}
             >
               Cancel
             </button>
             <button
               type="button"
               onClick={handleBulkDeleteConfirm}
-              className="flex-1 py-1 rounded text-[11px] text-white bg-error-bg hover:opacity-90 transition-opacity duration-fast"
+              className={[
+                'flex-1 py-1 rounded text-[11px] text-white bg-error-bg hover:opacity-90 transition-opacity duration-fast',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1',
+              ].join(' ')}
             >
               Delete
             </button>

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -378,7 +378,7 @@ function ThreadActionMenu({
               role="menuitem"
               tabIndex={-1}
               onClick={() => { onUnarchive(); closeAndReturnFocus(); }}
-              className="w-full text-left px-3 py-1.5 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast"
+              className="w-full text-left px-3 py-1.5 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset"
             >
               Unarchive
             </button>
@@ -388,7 +388,7 @@ function ThreadActionMenu({
               role="menuitem"
               tabIndex={-1}
               onClick={() => { onArchive(); closeAndReturnFocus(); }}
-              className="w-full text-left px-3 py-1.5 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast"
+              className="w-full text-left px-3 py-1.5 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset"
             >
               Archive
             </button>
@@ -398,7 +398,7 @@ function ThreadActionMenu({
             role="menuitem"
             tabIndex={-1}
             onClick={() => setMenuState({ type: 'group-input' })}
-            className="w-full text-left px-3 py-1.5 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast"
+            className="w-full text-left px-3 py-1.5 text-text-secondary hover:bg-hover hover:text-text-primary transition-colors duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset"
           >
             Move to group&hellip;
           </button>
@@ -407,7 +407,7 @@ function ThreadActionMenu({
             role="menuitem"
             tabIndex={-1}
             onClick={() => setMenuState({ type: 'confirm-delete' })}
-            className="w-full text-left px-3 py-1.5 text-error hover:bg-hover transition-colors duration-fast"
+            className="w-full text-left px-3 py-1.5 text-error hover:bg-hover transition-colors duration-fast focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset"
           >
             Delete
           </button>
@@ -1276,7 +1276,7 @@ export function Sidebar({
           'absolute right-0 top-0 h-full w-1 z-30',
           'cursor-col-resize',
           'hover:bg-border-strong focus-visible:bg-border-strong',
-          'focus-visible:outline-none',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus',
           // Hide drag handle on mobile — fixed-width drawer, no resize affordance
           'hidden md:block',
           isDragging ? 'bg-border-strong' : 'bg-transparent',


### PR DESCRIPTION
## Summary

Batch of four accessibility issues addressed in one session:

**#212 — Full keyboard focus indicator audit + fix**
- `ThreadRow` main row button: added `focus-visible:ring-2 ring-focus ring-inset`
- `ArchiveToggle` Active/Archived buttons: added `focus-visible:ring-2 ring-focus ring-inset`
- `BulkActionBar` Clear, Archive selected, Delete selected buttons: added `focus-visible:ring-2 ring-focus ring-offset-1`
- `ThreadActionMenu` confirm-delete Cancel and Delete: added `focus-visible:ring-2`
- `ThreadActionMenu` group-input suggestion buttons: added `focus-visible:ring-2`
- `ThreadActionMenu` group-input Cancel and Confirm buttons: added `focus-visible:ring-2`
- `ThreadActionMenu` group-input textarea: fixed `focus:ring` → `focus-visible:ring` (hard project rule)
- `ModelSelectorPanel` AddModelButton dropdown menu items: added `focus-visible:ring-2`

**#205 — BulkActionBar confirm-delete buttons missing focus-visible ring**
- Both Cancel and Delete buttons in the BulkActionBar confirm-delete sub-state now have `focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-1` (handled as part of the #212 sweep above)

**#210 — InputBar ghost mode tooltip: 600ms hover delay**
- Replaced CSS `group-hover:opacity-100` with JS `setTimeout(600ms)` on `mouseenter` per `tooltip.md §1`
- `mouseleave` clears timer and hides immediately
- Added `id` + `aria-describedby` to wire the ARIA tooltip pattern (`role="tooltip"` was already present)
- Added caret to the tooltip for visual consistency with `InteractionModeSwitcher` tooltips

**#211 — InteractionModeSwitcher tooltip: 600ms hover delay**
- Added `useState`/`useRef`/`useCallback` for tooltip visibility per `ModeButton` instance
- `onMouseEnter`: sets 600ms timer before showing (intentionality filter)
- `onMouseLeave`: clears timer, hides immediately
- `onFocus`: shows immediately (0ms — keyboard users get instant feedback)
- `onBlur` + `Escape` key: hides immediately
- Removed `group` class from wrapper div (tooltips are no longer CSS-driven)
- Applied to both interactive buttons and non-interactive `comingSoon` spans

## Files changed
- `src/ui/InputBar.tsx`
- `src/ui/InteractionModeSwitcher.tsx`
- `src/ui/ModelSelectorPanel.tsx`
- `src/ui/Sidebar.tsx`

## Test plan
- [ ] All 837 existing tests pass (`npm run test:run` ✓)
- [ ] `npm run lint` passes ✓
- [ ] `npm run build` passes ✓
- [ ] Keyboard tab through the sidebar conversation list — each row shows a visible focus ring
- [ ] Tab into BulkActionBar (select a conversation to trigger it) — Clear, Archive, Delete, and confirm-delete buttons all show rings
- [ ] Tab through ArchiveToggle — Active/Archived show rings
- [ ] Hover `InteractionModeSwitcher` buttons — tooltip appears after ~600ms, not immediately
- [ ] Tab to `InteractionModeSwitcher` Parallel button — tooltip appears instantly on focus
- [ ] Hover InputBar ghost mode icon — tooltip appears after ~600ms (need ghost mode active)
- [ ] All focus rings use `focus-visible:` not `focus:` — rings do not appear on mouse click

🤖 Generated with [Claude Code](https://claude.com/claude-code)