### PR TITLE
refactor(types): define SessionTokenUsage as TokenUsage intersection (#144)

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -132,13 +132,13 @@ export interface TokenUsage {
 /**
  * Running session totals for a single model. Aria reads this to display
  * per-model usage in the UI (issue #15 / #16).
+ *
+ * Defined as a `TokenUsage` intersection to eliminate field duplication (#144).
+ * The shape is structurally identical to the previous explicit definition —
+ * all existing object literals `{ modelId, inputTokens, outputTokens, totalTokens }`
+ * continue to satisfy this type without modification.
  */
-export interface SessionTokenUsage {
-  modelId: ModelId;
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-}
+export type SessionTokenUsage = { modelId: ModelId } & TokenUsage;
 
 // ─── Messages ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What changed

`SessionTokenUsage` previously duplicated the three fields from `TokenUsage` (`inputTokens`, `outputTokens`, `totalTokens`) while adding a single `modelId: ModelId` field. This PR eliminates the duplication by redefining `SessionTokenUsage` as an intersection type:

```ts
// before
export interface SessionTokenUsage {
  modelId: ModelId;
  inputTokens: number;
  outputTokens: number;
  totalTokens: number;
}

// after
export type SessionTokenUsage = { modelId: ModelId } & TokenUsage;
```

## Backward compatibility

The new definition is **structurally identical** to the previous one — TypeScript's intersection type `{ modelId: ModelId } & TokenUsage` expands to exactly the same set of required fields. Every existing object literal of the form `{ modelId, inputTokens, outputTokens, totalTokens }` satisfies both the old and the new type without modification.

Confirmed consumers that require no changes:
- `Atlas` — `sendMessage.ts`: constructs `SessionTokenUsage` literals and accumulates fields in a `Map<ModelId, SessionTokenUsage>`. Compiles unchanged.
- `Vault` — `useConversationStore.ts`: delegates to Atlas's `computeSessionTokenUsage` and types the return. Compiles unchanged.
- `Aria` — `ModelSelectorPanel.tsx`, `RoundtableContext.tsx`, `App.tsx`: all consume `SessionTokenUsage[]` by reading `modelId`, `inputTokens`, `outputTokens`, `totalTokens` fields. Compiles unchanged.
- `Scout` — integration tests in `get-session-token-usage.test.ts` and `storage-store.test.ts`: construct literal objects; all satisfy the intersection. Compiles unchanged.

## Verification

- `npm run lint` — passes (0 warnings, 0 errors)
- `npm run build` — passes (tsc + vite, 261 modules, no type errors)

## Design decision

Used `type` (not `interface`) for the intersection because TypeScript only supports intersection (`&`) with `type` aliases — `interface extends` could achieve a similar result but requires re-declaring the inherited fields or using a class-style inheritance chain, which is more verbose and less direct for this use case. The `type` alias is equivalent in every respect that matters to consumers.

No new dependencies introduced.